### PR TITLE
Include '-dirty' in the version string if it is

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -27,7 +27,7 @@
   <echo message="Looking for git version tag..." />
      <exec executable="git" outputproperty="code-version" 
            errorproperty="code-version" failifexecutionfails="false">
-        <arg line="describe --tags" />
+        <arg line="describe --tags --dirty" />
       </exec>
   <echo message="git version string: ${code-version}" />
 


### PR DESCRIPTION
week2-40-gcd89a3c becomes week2-40-gcd89a3c-dirty if there were any
modifications since the last commit.

e.g.

```
     [echo] Looking for git version tag...
     [echo] git version string: week2-45-g3f0b380-dirty

```