### PR TITLE
Fix Motor Safety and Remove Annoying Log Messages

### DIFF
--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -270,10 +270,6 @@ public class Drivetrain extends SpartronicsSubsystem
                 {
                     m_robotDrive.arcadeDrive(forward, rotation);
                 }
-                else
-                {
-                    m_logger.debug("joystick is within deadzone for both axies so driving is disabled" + forward + " " + rotation);
-                }
             }
             else
             {

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -266,10 +266,13 @@ public class Drivetrain extends SpartronicsSubsystem
             {
                 double forward = m_driveStick.getY();
                 double rotation = m_driveStick.getX();
-                if (Math.abs(forward) > 0.02 | Math.abs(rotation) > 0.02)
+                if (Math.abs(forward) < 0.02 && Math.abs(rotation) < 0.02)
                 {
-                    m_robotDrive.arcadeDrive(forward, rotation);
+                    // To keep motor saftey happy
+                    forward = 0.0;
+                    rotation = 0.0;
                 }
+                m_robotDrive.arcadeDrive(forward, rotation);
             }
             else
             {


### PR DESCRIPTION
* We now always set a value for arcadeDrive to keep motor safety happy
* Deadzone code is refactored so that it is simpler, but is functionally the same
* The annoying log message is dead. Long live the annoying log message! (Just kidding, it's really gone)