### PR TITLE
Example implementation of selectable USB cameras

### DIFF
--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -26,6 +26,8 @@ import org.usfirst.frc.team4915.steamworks.commands.ReverseArcadeDriveCommand;
 import org.usfirst.frc.team4915.steamworks.subsystems.Climber;
 import org.usfirst.frc.team4915.steamworks.subsystems.Intake.State;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher.LauncherState;
+import org.usfirst.frc.team4915.steamworks.commands.ChooseCameraCommand;
+import org.usfirst.frc.team4915.steamworks.subsystems.Cameras;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Joystick;
@@ -54,6 +56,10 @@ public class OI
     public final JoystickButton m_intakeReverse = new JoystickButton(m_driveStick, 4);
     
     public final JoystickButton m_reverseDrive = new JoystickButton(m_driveStick, 3);
+
+    public final JoystickButton m_cameraFwd = new JoystickButton(m_driveStick, 12);
+    public final JoystickButton m_cameraRev = new JoystickButton(m_driveStick, 13);
+
 
     //Aux Stick Buttons
     public final JoystickButton m_climberOn = new JoystickButton(m_auxStick, 11);
@@ -103,6 +109,7 @@ public class OI
         initDrivetrainOI();
         initIntakeOI();
         initLauncherOI();
+        initChooseCameraOI();
         initClimberOI();
 
         // Init loggers last, as this uses special values generated when other loggers are created.
@@ -290,6 +297,12 @@ public class OI
     	m_launcherOff.whenPressed(new LauncherCommand(m_robot.getLauncher(), LauncherState.OFF));
     	m_launcherSingle.whenPressed(new LauncherCommand(m_robot.getLauncher(), LauncherState.SINGLE));
         // includes carousel
+    }
+
+    private void initChooseCameraOI()
+    {
+        m_cameraFwd.whenPressed(new ChooseCameraCommand(m_robot.getCameras(), Cameras.CAM_FWD));
+        m_cameraRev.whenPressed(new ChooseCameraCommand(m_robot.getCameras(), Cameras.CAM_REV));
     }
 
     private void initLoggers()

--- a/src/org/usfirst/frc/team4915/steamworks/Robot.java
+++ b/src/org/usfirst/frc/team4915/steamworks/Robot.java
@@ -7,6 +7,7 @@ import org.usfirst.frc.team4915.steamworks.subsystems.Drivetrain;
 import org.usfirst.frc.team4915.steamworks.subsystems.Intake;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher.LauncherState;
+import org.usfirst.frc.team4915.steamworks.subsystems.Cameras;
 
 import edu.wpi.first.wpilibj.IterativeRobot;
 import edu.wpi.first.wpilibj.command.Command;
@@ -23,7 +24,7 @@ public class Robot extends IterativeRobot
     private Intake m_intake;
     private OI m_oi;
     private Climber m_climber;
-    
+    private Cameras m_cameras;
 
     private Launcher m_launcher;
 
@@ -34,6 +35,7 @@ public class Robot extends IterativeRobot
         m_intake = new Intake();
         m_drivetrain = new Drivetrain();
         m_climber = new Climber();
+        m_cameras = new Cameras();
         m_launcher = new Launcher();
         m_oi = new OI(this); // make sure OI is last
     }
@@ -58,10 +60,14 @@ public class Robot extends IterativeRobot
     {
         return m_drivetrain;
     }
-    
+
+    public Cameras getCameras() {
+        return m_cameras;
+    }
+
     public Launcher getLauncher() {
-		return m_launcher;
-	}
+        return m_launcher;
+    }
 
     @Override
     public void autonomousInit()

--- a/src/org/usfirst/frc/team4915/steamworks/commands/ChooseCameraCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/ChooseCameraCommand.java
@@ -1,0 +1,57 @@
+package org.usfirst.frc.team4915.steamworks.commands;
+
+import org.usfirst.frc.team4915.steamworks.subsystems.Cameras;
+
+import edu.wpi.first.wpilibj.command.Command;
+
+/**
+ *
+ */
+public class ChooseCameraCommand extends Command
+{
+
+    private final Cameras m_cameras;
+    private int m_whichCamera;
+
+    public ChooseCameraCommand(Cameras cameras, int whichCamera)
+    {
+        m_cameras = cameras;
+        m_whichCamera = whichCamera;
+        requires(m_cameras);
+    }
+
+    @Override
+    public void initialize()
+    {
+        m_cameras.changeCamera(m_whichCamera);
+
+        // Log the selection for debugging?
+        /*
+        if (m_camera == Cameras.CameraType.CAM_FWD) {
+        }
+        else if (m_camera == Cameras.CameraType.CAM_REV) {
+        }
+        */
+    }
+
+    @Override
+    public void execute()
+    {
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return true;    // Once we're done, we're done...
+    }
+
+    @Override
+    public void interrupted()
+    {
+    }
+
+    @Override
+    public void end()
+    {
+    }
+}

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Cameras.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Cameras.java
@@ -1,0 +1,163 @@
+package org.usfirst.frc.team4915.steamworks.subsystems;
+
+import org.usfirst.frc.team4915.steamworks.Logger;
+
+import edu.wpi.cscore.UsbCamera;
+import edu.wpi.cscore.UsbCameraInfo;
+import edu.wpi.cscore.MjpegServer;
+import edu.wpi.cscore.VideoMode;
+
+public class Cameras extends SpartronicsSubsystem
+{
+    // Values used by changeCamera() method
+    public static final int CAM_FWD = 0;
+    public static final int CAM_REV = 1;
+    public static final int CAM_NONE = 2;
+
+    private static final int imageWidth = 320;
+    private static final int imageHeight = 240;
+    private static final int frameRate = 20;
+
+    private static final int serverPort = 1180;
+
+    // Save space in an array for two USB cameras
+    private UsbCamera m_camera[] = new UsbCamera[2];
+
+    private int m_numCameras;   // Track the number of cameras we have
+
+    private MjpegServer m_mjpegServer;  // The camera server object
+
+    private Logger m_logger;
+
+    public Cameras() {
+        m_logger = new Logger("Cameras", Logger.Level.DEBUG);
+
+        m_logger.info("Constructor called");
+
+        m_numCameras=0;         // Initialize the camera counter
+
+        // Get a list of attached USB cameras
+        UsbCameraInfo camInfo[] = UsbCamera.enumerateUsbCameras();
+
+        // Go through the list of camera info and set up the cameras
+        for (int i=0 ; i<camInfo.length ; i++)
+        {
+            // Only assign CAM_FWD and CAM_REV (and assume that the first
+            // camera in the list is CAM_FWD -- is this a good assumption?)
+            if (m_numCameras <= CAM_REV)
+            {
+                // Create a new camera instance
+                m_camera[m_numCameras] =
+                    new UsbCamera(camInfo[i].name, camInfo[i].dev);
+
+                // Configure camera settings
+                m_camera[m_numCameras].setVideoMode(
+                        VideoMode.PixelFormat.kMJPEG,
+                        imageWidth, imageHeight, frameRate);
+
+                // Debugging in case logger is not working
+                // System.out.println("Camera " + m_numCameras +
+                //       " (" + camInfo[i].dev + ") " + ": " + camInfo[i].name);
+
+                m_logger.info("Camera " + m_numCameras +
+                        " (" + camInfo[i].dev + ") " + ": " + camInfo[i].name);
+
+                m_numCameras++; // Increment our camera counter
+            }
+            else
+            {
+                // If there were extra cameras in the list, log them
+
+                // Debugging in case logger is not working
+                // System.out.println("Unexpected source found ("
+                //      + camInfo[i].dev + ") " + ": " + camInfo[i].name);
+
+                m_logger.info("Unexpected source found ("
+                        + camInfo[i].dev + ") " + ": " + camInfo[i].name);
+            }
+        }
+
+        // Now that all the cameras have been found, set their modes and
+        // start up the server
+        if (m_numCameras >= CAM_FWD)
+        {
+            // Create camera network server, and assign the first camera
+            m_mjpegServer = new MjpegServer("USB Camera Server", serverPort);
+            m_mjpegServer.setSource(m_camera[CAM_FWD]);
+        }
+
+        m_logger.info("Constructor finished, " + m_numCameras + " found");
+
+        // Debugging in case logger is not working
+        // System.out.println("Cameras(): Constructor done, " + m_numCameras +
+        //      " found");
+    }
+
+    public boolean changeCamera(int camera) {
+        boolean status = false;
+        switch (camera)
+        {
+            case CAM_NONE:
+                // TODO (if a "blank" stream is desired)
+                // Create a static video source with CvSource, and
+                // assign it to the mjpegServer
+                // Idea: Make the source a static picture of a test pattern
+                m_logger.info("Selecting CAM_NONE");
+                break;
+
+            case CAM_FWD:
+                // First check to make sure we have this camera available
+                if (m_numCameras >= CAM_FWD)
+                {
+                    if (m_camera[CAM_FWD].isValid())
+                    {
+                        m_logger.info("Selecting CAM_FWD");
+                        // Assign the selected camera to the streaming server
+                        m_mjpegServer.setSource(m_camera[CAM_FWD]);
+                        status = true;      // We have been successful!
+                    }
+                    else
+                    {
+                        m_logger.info("CAM_FWD is invalid!");
+                    }
+                }
+                else
+                {
+                    m_logger.info("No CAM_FWD!");
+                }
+                break;
+
+            case CAM_REV:
+                // First check to make sure we have this camera available
+                if (m_numCameras >= CAM_REV)
+                {
+                    if (m_camera[CAM_REV].isValid())
+                    {
+                        m_logger.info("Selecting CAM_REV");
+                        // Assign the selected camera to the streaming server
+                        m_mjpegServer.setSource(m_camera[CAM_REV]);
+                        status = true;      // We have been successful!
+                    }
+                    else
+                    {
+                        m_logger.info("CAM_REV is invalid!");
+                    }
+                }
+                else
+                {
+                    m_logger.info("No CAM_REV!");
+                }
+                break;
+
+            default:
+                m_logger.info("Invalid camera: " + camera);
+                break;
+        }
+        return status;
+    }
+
+    @Override
+    protected void initDefaultCommand() {
+        // No default command
+    }
+}


### PR DESCRIPTION
One MjpegServer, and two UsbCameras, with the camera source
selectable by button press.

Currently uses button 12 (forward) and 13 (reverse) on Xbox controller.