### PR TITLE
More autonomous, climber speed

### DIFF
--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -30,6 +30,7 @@ import org.usfirst.frc.team4915.steamworks.commands.ChooseCameraCommand;
 import org.usfirst.frc.team4915.steamworks.subsystems.Cameras;
 
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.buttons.JoystickButton;
@@ -213,13 +214,13 @@ public class OI
         }
         try
         {
-            String alliance = DriverStation.getInstance().getAlliance().toString();
+            Alliance alliance = DriverStation.getInstance().getAlliance();
             if (alliance == null)
             {
                 m_logger.error("We're not on an alliance?");
                 return;
             }
-            String other = alliance.equals("Blue") ? "Red" : "Blue";
+            String other = alliance.toString().equals("Blue") ? "Red" : "Blue";
             Files.list(root)
                     .filter(Files::isReadable)
                     .map(Path::getFileName)

--- a/src/org/usfirst/frc/team4915/steamworks/commands/RecordingSetCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/RecordingSetCommand.java
@@ -26,6 +26,11 @@ public class RecordingSetCommand extends Command
     @Override
     public void execute()
     {
+        if (!m_drivetrain.getRecordingEnabled())
+        {
+            return;
+        }
+
         if (m_state)
         {
             m_drivetrain.startRecording();

--- a/src/org/usfirst/frc/team4915/steamworks/commands/ReplayCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/ReplayCommand.java
@@ -13,16 +13,21 @@ public class ReplayCommand extends Command
 
     private final Drivetrain m_drivetrain;
     private final Launcher m_launcher;
+    private final Command m_launcherOn;
+    private final Command m_launcherOff;
     private List<Double> m_replayForward;
     private List<Double> m_replayRotation;
     private int m_currentStep;
-    private int m_launchAt = 0;
+    private int m_launchStart = 0;
+    private int m_launchStop = 0;
     private boolean m_finished = false;
 
     public ReplayCommand(Drivetrain drivetrain, Launcher launcher)
     {
         m_drivetrain = drivetrain;
         m_launcher = launcher;
+        m_launcherOn = new LauncherCommand(m_launcher, LauncherState.ON);
+        m_launcherOff = new LauncherCommand(m_launcher, LauncherState.OFF);
         requires(m_drivetrain);
     }
 
@@ -35,10 +40,19 @@ public class ReplayCommand extends Command
     @Override
     public void execute()
     {
-        if (m_launchAt != 0 && m_currentStep == m_launchAt)
+        if (m_launchStart != 0)
         {
-            m_drivetrain.m_logger.notice("Launching");
-            new LauncherCommand(m_launcher, LauncherState.ON).start();
+            if (m_currentStep == m_launchStart)
+            {
+                m_drivetrain.m_logger.notice("Launching in replay");
+                m_launcherOn.start();
+            }
+            else if (m_currentStep == m_launchStop)
+            {
+                m_drivetrain.m_logger.notice("Stopped launching in replay");
+                m_launcherOn.cancel();
+                m_launcherOff.start();
+            }
         }
         if (m_currentStep++ >= m_replayForward.size())
         {
@@ -65,7 +79,8 @@ public class ReplayCommand extends Command
         m_replayForward = m_drivetrain.getReplayForward();
         m_replayRotation = m_drivetrain.getReplayRotation();
         m_currentStep = 0;
-        m_launchAt = m_drivetrain.getReplayLaunch();
+        m_launchStart = m_drivetrain.getReplayLaunchStart();
+        m_launchStop = m_drivetrain.getReplayLaunchStop();
         m_finished = false;
     }
 

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Climber.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Climber.java
@@ -1,9 +1,5 @@
 package org.usfirst.frc.team4915.steamworks.subsystems;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.usfirst.frc.team4915.steamworks.Logger;
 import org.usfirst.frc.team4915.steamworks.RobotMap;
 
@@ -24,9 +20,6 @@ public class Climber extends SpartronicsSubsystem
         ON,
         SLOW
     }
-
-    //Shows climber speed 
-    private static final double CLIMBER_SPEED = 0.75;
     
     private CANTalon m_climberMotor;
 
@@ -76,13 +69,17 @@ public class Climber extends SpartronicsSubsystem
     }
     
     public double getClimberSpeed(State s) {
+        double speed = SmartDashboard.getNumber("Climber Speed", .75);
         switch(s)
         {
-            case ON: return CLIMBER_SPEED;
-            case SLOW: return CLIMBER_SPEED * .5;
-            case OFF: return 0;
+            case ON:
+                return speed;
+            case SLOW:
+                return speed / 2;
+            case OFF:
+            default:
+                return 0;
         }
-        return 0;
     }
 
     public void setClimber(State s) // NB: this is called during execute! (limit log / dashboard traffic)

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -505,7 +505,7 @@ public class Drivetrain extends SpartronicsSubsystem
                     forward = 0.0;
                     rotation = 0.0;
                 }
-                if (m_isRecording)
+                if (getRecordingEnabled() && m_isRecording)
                 {
                     m_replayForward.add(forward); 
                     m_replayRotation.add(rotation);
@@ -668,6 +668,10 @@ public class Drivetrain extends SpartronicsSubsystem
 
     public void startRecording()
     {
+        if (!getRecordingEnabled())
+        {
+            return;
+        }
         m_startedRecordingAt = Instant.now();
         m_logger.notice("Started recording at " + m_startedRecordingAt);
 
@@ -799,6 +803,11 @@ public class Drivetrain extends SpartronicsSubsystem
             m_logger.exception(e, false);
             return false;
         }
+    }
+
+    public boolean getRecordingEnabled()
+    {
+        return SmartDashboard.getBoolean("RecordingEnabled", false);
     }
 
     public List<Double> getReplayForward()

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -20,6 +20,7 @@ import org.usfirst.frc.team4915.steamworks.sensors.IMUPIDSource;
 import com.ctre.CANTalon;
 import com.ctre.CANTalon.FeedbackDevice;
 import com.ctre.CANTalon.TalonControlMode;
+
 import edu.wpi.first.wpilibj.DigitalOutput;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.Joystick;
@@ -94,10 +95,11 @@ public class Drivetrain extends SpartronicsSubsystem
     private Instant m_startedRecordingAt;
     private final List<Double> m_replayForward = new ArrayList<>();
     private final List<Double> m_replayRotation = new ArrayList<>();
+    private int m_replayLaunchStart = 0;
+    private int m_replayLaunchStop = 0;
     
     //Reverse
     private boolean m_reverseIsOn = false;
-    private int m_replayLaunch = 0;
 
 
     public Drivetrain()
@@ -714,15 +716,17 @@ public class Drivetrain extends SpartronicsSubsystem
                 String[] rotationFromFile = lines.get(1).split(",");
                 if (lines.size() > 2)
                 {
-                    m_replayLaunch = Integer.valueOf(lines.get(2));
-                    if (m_replayLaunch >= forwardFromFile.length || m_replayLaunch < 0)
+                    String[] launchFromFile = lines.get(2).split(",");
+                    m_replayLaunchStart = Integer.valueOf(launchFromFile[0]);
+                    m_replayLaunchStop = Integer.valueOf(launchFromFile[1]);
+                    if (m_replayLaunchStart >= forwardFromFile.length || m_replayLaunchStart < 0 || m_replayLaunchStop < m_replayLaunchStart)
                     {
-                        m_logger.debug("Supposed to launch at an invalid step (" + m_replayLaunch + "), max " + forwardFromFile.length);
-                        m_replayLaunch = 0;
+                        m_logger.debug("Supposed to launch at an invalid step (" + m_replayLaunchStart + "), max " + forwardFromFile.length);
+                        m_replayLaunchStart = 0;
                     }
                     else
                     {
-                        m_logger.debug("Will launch at step number " + m_replayLaunch);
+                        m_logger.debug("Will launch at step number " + m_replayLaunchStart);
                     }
                 }
                 else
@@ -807,9 +811,14 @@ public class Drivetrain extends SpartronicsSubsystem
         return m_replayRotation;
     }
 
-    public int getReplayLaunch()
+    public int getReplayLaunchStart()
     {
-        return m_replayLaunch;
+        return m_replayLaunchStart;
+    }
+
+    public int getReplayLaunchStop()
+    {
+        return m_replayLaunchStop;
     }
 
 }


### PR DESCRIPTION
- Global recording toggle
- Start *and* stop launcher timings in replays
- Reads climber speed from SmartDashboard under "Climber Speed"