### PR TITLE
Disabled USB camera switch buttons

### DIFF
--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -26,9 +26,6 @@ import org.usfirst.frc.team4915.steamworks.commands.ReverseArcadeDriveCommand;
 import org.usfirst.frc.team4915.steamworks.subsystems.Climber;
 import org.usfirst.frc.team4915.steamworks.subsystems.Intake.State;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher.LauncherState;
-import org.usfirst.frc.team4915.steamworks.commands.ChooseCameraCommand;
-import org.usfirst.frc.team4915.steamworks.subsystems.Cameras;
-
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Joystick;
@@ -58,8 +55,8 @@ public class OI
 
     public final JoystickButton m_reverseDrive = new JoystickButton(m_driveStick, 3);
 
-    public final JoystickButton m_cameraFwd = new JoystickButton(m_driveStick, 7);
-    public final JoystickButton m_cameraRev = new JoystickButton(m_driveStick, 8);
+    //public final JoystickButton m_cameraFwd = new JoystickButton(m_driveStick, 7);
+    //public final JoystickButton m_cameraRev = new JoystickButton(m_driveStick, 8);
 
     //Aux Stick Buttons
     public final JoystickButton m_climberOn = new JoystickButton(m_auxStick, 11);
@@ -304,8 +301,8 @@ public class OI
 
     private void initChooseCameraOI()
     {
-        m_cameraFwd.whenPressed(new ChooseCameraCommand(m_robot.getCameras(), Cameras.CAM_FWD));
-        m_cameraRev.whenPressed(new ChooseCameraCommand(m_robot.getCameras(), Cameras.CAM_REV));
+        //m_cameraFwd.whenPressed(new ChooseCameraCommand(m_robot.getCameras(), Cameras.CAM_FWD));
+        //m_cameraRev.whenPressed(new ChooseCameraCommand(m_robot.getCameras(), Cameras.CAM_REV));
     }
 
     private void initLoggers()

--- a/src/org/usfirst/frc/team4915/steamworks/commands/ReverseArcadeDriveCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/ReverseArcadeDriveCommand.java
@@ -43,7 +43,7 @@ public class ReverseArcadeDriveCommand extends Command
         m_drivetrain.m_logger.info("ReverseArcadeDriveCommand initialize");;
         m_drivetrain.setControlMode(TalonControlMode.PercentVbus, 12.0, -12.0, 
                                     0, 0, 0, 0 /* zero PIDF  */);
-        m_drivetrain.setReverse(m_cameras);
+        m_drivetrain.setReverse();
 
     }
 

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -542,12 +542,11 @@ public class Drivetrain extends SpartronicsSubsystem
         }
     }
     
-    public void setReverse(Cameras m_cameras)
+    public void setReverse()
     {
         
         m_reverseIsOn = true;
         m_lightOutput.set(true);
-        m_cameras.changeCamera(Cameras.CAM_REV);
         SmartDashboard.putString("ReverseEnabled", "Enabled");
 
     }


### PR DESCRIPTION
We have only one USB camera, so the call to the Reverse camera was disabled. The buttons were also disabled for simplicity. 