### PR TITLE
Tune PID and Slow Turning

### DIFF
--- a/src/org/usfirst/frc/team4915/steamworks/commands/TurnDegreesIMUCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/TurnDegreesIMUCommand.java
@@ -29,7 +29,7 @@ public class TurnDegreesIMUCommand extends Command
         m_targetCounter = 0;
         // Will the IMU be initialized by the time we get here?
         m_drivetrain.endIMUTurn();
-        m_drivetrain.setControlMode(TalonControlMode.PercentVbus, 6.0, -6.0,
+        m_drivetrain.setControlMode(TalonControlMode.PercentVbus, 3.0, -3.0, // This is the same as DriveStraight because it is probably overriden if a command is run before it
                 0, 0, 0, 0 /* zeros since we're not in closed-loop */);
         m_drivetrain.startIMUTurnAbsolute(m_degrees);
         m_drivetrain.m_logger.debug("TurnDegreesIMUCommand I want to turn  "+m_degrees+" degrees.");

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -28,6 +28,7 @@ import edu.wpi.first.wpilibj.PIDController;
 import edu.wpi.first.wpilibj.PIDOutput;
 import edu.wpi.first.wpilibj.RobotDrive;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /* on Declan's choice for motor names: http://oceanservice.noaa.gov/facts/port-starboard.html
@@ -85,16 +86,10 @@ public class Drivetrain extends SpartronicsSubsystem
     private PIDController m_turningPIDController;
     private IMUPIDSource m_imuPIDSource;
 
-    private static final double turnKp = 0.12;
+    private static final double turnKp = 0.11;
     private static final double turnKi = 0.01;
-    private static final double turnKd = 0.145;
+    private static final double turnKd = 0.3;
     private static final double turnKf = 0.001;
-    
-    // Was
-//    private static final double turnKp = 0.12;
-//    private static final double turnKi = 0.01;
-//    private static final double turnKd = 0.145;
-//    private static final double turnKf = 0.001;
 
     // Replay
     private boolean m_isRecording = false;
@@ -138,7 +133,7 @@ public class Drivetrain extends SpartronicsSubsystem
                                                         // in open-loop mode (PercentVbus) we must apply the output inversion explicitly.
                                                         // or we can invoke m_robotDrive.setLeftRightMotorOutputs(leftOutput, rightOutput).
 
-            // Setup the motor so it has an encoder
+            // Setup the motors so it has an encoder
             m_portMasterMotor.setFeedbackDevice(FeedbackDevice.QuadEncoder);
             m_starboardMasterMotor.setFeedbackDevice(FeedbackDevice.QuadEncoder);
 
@@ -200,7 +195,6 @@ public class Drivetrain extends SpartronicsSubsystem
             
             m_lightOutput = new DigitalOutput(LIGHT_OUTPUT_PORT);
             SmartDashboard.putString("ReverseEnabled", "Disabled");
-
 
             // Debug stuff so everyone knows that we're initialized
             m_logger.info("initialized successfully"); // Tell everyone that the drivetrain is initialized successfully


### PR DESCRIPTION
* PID is now tuned to fix the oscillation we saw at the end of drive straight and cross baseline
* TurnDegreesIMUCommand has a peak output voltage of 3 and -3 instead of 6 and -6