### PR TITLE
Add PID Tuning, Extra Group Parameters, Side Gear Placement, and Straight+Curved Driving

### DIFF
--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -21,6 +21,7 @@ import org.usfirst.frc.team4915.steamworks.commands.ReverseArcadeDriveCommand;
 import org.usfirst.frc.team4915.steamworks.commands.groups.ParameterizedCommandGroup;
 import org.usfirst.frc.team4915.steamworks.subsystems.Climber;
 import org.usfirst.frc.team4915.steamworks.subsystems.Drivetrain;
+import org.usfirst.frc.team4915.steamworks.subsystems.Intake;
 import org.usfirst.frc.team4915.steamworks.subsystems.Intake.State;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher.LauncherState;
@@ -233,23 +234,24 @@ public class OI
         {
             Drivetrain drivetrain = m_robot.getDrivetrain();
             Launcher launcher = m_robot.getLauncher();
+            Intake intake = m_robot.getIntake();
             String name = strategy.replaceFirst("Preset: ", "");
             switch (name)
             {
                 case "Cross Baseline Positons 1+3":
                     // This is the length from the diamond plate to the baseline
-                    result = new ParameterizedCommandGroup(drivetrain, launcher, this,
+                    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
                             "Drive", "-93.3");
                     break;
                 case "Place Gear Position 2":
                     // This is the length from the diamond plate with the robot length subtracted and the 8 
                     //  subtracted to account for the spring and the inset of the gear on the robot
-                    result = new ParameterizedCommandGroup(drivetrain, launcher, this,
+                    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
                             "Drive", "" + (-114.3 + (RobotMap.ROBOT_LENGTH - 3)));
                     break;
                 case "Drive and Shoot Position 3":
                     // We drive forward, turn to be parallel with the boiler, and drive into the boiler
-                    result = new ParameterizedCommandGroup(drivetrain, launcher, this,
+                    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
                             "Drive", "" + (-42 + returnForSide(m_alliance, 0, 10)),
                             "Turn", "-45",
                             "Drive Timeout", "" + (37 + returnForSide(m_alliance, 0, -3)), "2.5",
@@ -257,7 +259,7 @@ public class OI
                     break;
                 case "Drive Shoot and Cross Baseline Position 3 with Curve":
                     // Do our regular shooting routine, then almost the exact opposite, and then drive over the baseline
-                    result = new ParameterizedCommandGroup(drivetrain, launcher, this,
+                    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
                             "Drive", "" + (-42 + returnForSide(m_alliance, 0, 10)),
                             "Turn", "-45",
                             "Drive Timeout", "" + (37 + returnForSide(m_alliance, 0, -3)), "2.5",

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -207,6 +207,7 @@ public class OI
         display.add("Preset: Drive and Shoot Position 3");
         display.add("Preset: Drive Shoot and Cross Baseline Position 3 with Curve");
         display.add("Preset: Drive to Hopper and Shoot from Boiler Position 3");
+        display.add("Drive to Side Gear Position 4");
 
         display.addAll(m_autoReplayOptions);
 
@@ -267,10 +268,22 @@ public class OI
                             "Shoot",
                             "Curve", "-125", "0.5");
                     break;
+        		case "Drive to Side Gear Position 4":
+        		    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
+        			    "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
+        			    "Turn", "-60",
+        			    "Drive", "-24.64");
+        		    break;
                 case "Drive to Hopper and Shoot from Boiler Position 3":
                     // Drive to the hopper, wait there to get balls, drive to the boiler
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
-                            "Straight and Curve", "20", "0.6", "10", "0.3", "false");
+                        "Straight and Curve", ""+((16+150)-RobotMap.ROBOT_LENGTH), "1", "40", "0.6", "false",
+        			    "Delay", "1",
+        			    "Drive Speed", "-45", "0.6",
+        			    "Delay", "1",
+        			    "Turn", "45",
+        			    "Delay", "1",
+        			    "Drive Speed", "30", "0.6");
                     break;
                 default:
                     break;

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -206,6 +206,7 @@ public class OI
         display.add("Preset: Place Gear Position 2");
         display.add("Preset: Drive and Shoot Position 3");
         display.add("Preset: Drive Shoot and Cross Baseline Position 3 with Curve");
+        display.add("Preset: Drive to Hopper and Shoot from Boiler Position 3");
 
         display.addAll(m_autoReplayOptions);
 
@@ -265,6 +266,11 @@ public class OI
                             "Drive Timeout", "" + (37 + returnForSide(m_alliance, 0, -3)), "2.5",
                             "Shoot",
                             "Curve", "-125", "0.5");
+                    break;
+                case "Drive to Hopper and Shoot from Boiler Position 3":
+                    // Drive to the hopper, wait there to get balls, drive to the boiler
+                    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
+                            "Straight and Curve", "20", "0.6", "10", "0.3", "false");
                     break;
                 default:
                     break;

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -277,7 +277,7 @@ public class OI
        		    break;
                 case "LEFT Gear Position 4":
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
-                        "Drive Speed", "" + -(135 - RobotMap.ROBOT_LENGTH), "0.3", // This drives forward 6 inches farther than the left side
+                        "Drive Speed", "" + -(133 - RobotMap.ROBOT_LENGTH), "0.3", // This drives forward 4 inches farther than the left side
                         "Turn Alliance Independent Timeout", "60", "4",
                         "Drive", "-24.64");
                     break;

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -207,7 +207,7 @@ public class OI
         display.add("Preset: Drive and Shoot Position 3");
         display.add("Preset: Drive Shoot and Cross Baseline Position 3 with Curve");
         display.add("Preset: Drive to Hopper and Shoot from Boiler Position 3");
-        display.add("Drive to Side Gear Position 4");
+        display.add("Preset: Drive to Side Gear Position 4");
 
         display.addAll(m_autoReplayOptions);
 
@@ -271,19 +271,19 @@ public class OI
         		case "Drive to Side Gear Position 4":
         		    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
         			    "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
-        			    "Turn", "-60",
+        			    "Turn Timeout", "-60", "4",
         			    "Drive", "-24.64");
         		    break;
                 case "Drive to Hopper and Shoot from Boiler Position 3":
                     // Drive to the hopper, wait there to get balls, drive to the boiler
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
-                        "Straight and Curve", ""+((16+150)-RobotMap.ROBOT_LENGTH), "1", "40", "0.6", "false",
+                        "Straight and Curve", ""+((16+150)-RobotMap.ROBOT_LENGTH), "1", "115", "0.5", "false",
         			    "Delay", "1",
-        			    "Drive Speed", "-45", "0.6",
+        			    "Drive Speed", "-110", "0.6",
         			    "Delay", "1",
-        			    "Turn", "45",
+        			    "Fast Turn", "45",
         			    "Delay", "1",
-        			    "Drive Speed", "30", "0.6");
+        			    "Drive Speed", "125", "0.6");
                     break;
                 default:
                     break;

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -268,12 +268,18 @@ public class OI
                             "Shoot",
                             "Curve", "-125", "0.5");
                     break;
-        		case "Drive to Side Gear Position 4":
+        		case "Drive to RIGHT Side Gear Position 4":
         		    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
         			    "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
         			    "Turn Timeout", "-60", "4",
         			    "Drive", "-24.64");
         		    break;
+                case "Drive to LEFT Side Gear Position 4":
+                    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
+                        "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
+                        "Turn Timeout", "60", "4",
+                        "Drive", "-24.64");
+                    break;
                 case "Drive to Hopper and Shoot from Boiler Position 3":
                     // Drive to the hopper, wait there to get balls, drive to the boiler
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -203,12 +203,12 @@ public class OI
         // all of them are backwards to keep the drivers not confused
         display.add("None");
         display.add("Preset: Cross Baseline Positons 1+3");
-        display.add("Preset: Place Gear Position 2");
+        display.add("Preset: CENTER Gear Position 2");
         display.add("Preset: Drive and Shoot Position 3");
         display.add("Preset: Drive Shoot and Cross Baseline Position 3 with Curve");
         display.add("Preset: Drive to Hopper and Shoot from Boiler Position 3");
-        display.add("Preset: Drive to RIGHT Side Gear Position 4");
-        display.add("Preset: Drive to LEFT Side Gear Position 4");
+        display.add("Preset: RIGHT Gear Position 5");
+        display.add("Preset: LEFT Gear Position 4");
 
         display.addAll(m_autoReplayOptions);
 
@@ -246,7 +246,7 @@ public class OI
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
                             "Drive", "-93.3");
                     break;
-                case "Place Gear Position 2":
+                case "CENTER Gear Position 2":
                     // This is the length from the diamond plate with the robot length subtracted and the 8 
                     //  subtracted to account for the spring and the inset of the gear on the robot
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
@@ -269,13 +269,13 @@ public class OI
                             "Shoot",
                             "Curve", "-125", "0.5");
                     break;
-        	case "Drive to RIGHT Side Gear Position 4":
+        	case "RIGHT Gear Position 5":
         	    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
         		    "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
         		    "Turn Alliance Independent Timeout", "-60", "4",
        			    "Drive", "-24.64");
        		    break;
-                case "Drive to LEFT Side Gear Position 4":
+                case "LEFT Gear Position 4":
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
                         "Drive Speed", "" + -(131 - RobotMap.ROBOT_LENGTH), "0.3", // This drives forward 2 inches farther than the left side
                         "Turn Alliance Independent Timeout", "60", "4",

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -284,12 +284,10 @@ public class OI
                 case "Drive to Hopper and Shoot from Boiler Position 3":
                     // Drive to the hopper, wait there to get balls, drive to the boiler
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
-                        "Straight and Curve", ""+((16+150)-RobotMap.ROBOT_LENGTH), "1", "115", "0.5", "false",
-        			    "Delay", "1",
+                        "Straight and Curve", ""+((28+150)-RobotMap.ROBOT_LENGTH), "1", "115", "0.9", "false",
+				    "Intake", "ON",
         			    "Drive Speed", "-110", "0.6",
-        			    "Delay", "1",
         			    "Fast Turn", "45",
-        			    "Delay", "1",
         			    "Drive Speed", "125", "0.6");
                     break;
                 default:

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -207,7 +207,8 @@ public class OI
         display.add("Preset: Drive and Shoot Position 3");
         display.add("Preset: Drive Shoot and Cross Baseline Position 3 with Curve");
         display.add("Preset: Drive to Hopper and Shoot from Boiler Position 3");
-        display.add("Preset: Drive to Side Gear Position 4");
+        display.add("Preset: Drive to RIGHT Side Gear Position 4");
+        display.add("Preset: Drive to LEFT Side Gear Position 4");
 
         display.addAll(m_autoReplayOptions);
 
@@ -276,7 +277,7 @@ public class OI
         		    break;
                 case "Drive to LEFT Side Gear Position 4":
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
-                        "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
+                        "Drive Speed", "" + -(131 - RobotMap.ROBOT_LENGTH), "0.3", // This drives forward 2 inches farther than the left side
                         "Turn Timeout", "60", "4",
                         "Drive", "-24.64");
                     break;

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -277,7 +277,7 @@ public class OI
        		    break;
                 case "LEFT Gear Position 4":
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
-                        "Drive Speed", "" + -(131 - RobotMap.ROBOT_LENGTH), "0.3", // This drives forward 2 inches farther than the left side
+                        "Drive Speed", "" + -(135 - RobotMap.ROBOT_LENGTH), "0.3", // This drives forward 6 inches farther than the left side
                         "Turn Alliance Independent Timeout", "60", "4",
                         "Drive", "-24.64");
                     break;

--- a/src/org/usfirst/frc/team4915/steamworks/OI.java
+++ b/src/org/usfirst/frc/team4915/steamworks/OI.java
@@ -269,16 +269,16 @@ public class OI
                             "Shoot",
                             "Curve", "-125", "0.5");
                     break;
-        		case "Drive to RIGHT Side Gear Position 4":
-        		    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
-        			    "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
-        			    "Turn Timeout", "-60", "4",
-        			    "Drive", "-24.64");
-        		    break;
+        	case "Drive to RIGHT Side Gear Position 4":
+        	    result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
+        		    "Drive Speed", "" + -(129 - RobotMap.ROBOT_LENGTH), "0.3",
+        		    "Turn Alliance Independent Timeout", "-60", "4",
+       			    "Drive", "-24.64");
+       		    break;
                 case "Drive to LEFT Side Gear Position 4":
                     result = new ParameterizedCommandGroup(drivetrain, launcher, intake, this,
                         "Drive Speed", "" + -(131 - RobotMap.ROBOT_LENGTH), "0.3", // This drives forward 2 inches farther than the left side
-                        "Turn Timeout", "60", "4",
+                        "Turn Alliance Independent Timeout", "60", "4",
                         "Drive", "-24.64");
                     break;
                 case "Drive to Hopper and Shoot from Boiler Position 3":

--- a/src/org/usfirst/frc/team4915/steamworks/commands/DriveStraightCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/DriveStraightCommand.java
@@ -37,7 +37,8 @@ public class DriveStraightCommand extends Command implements PIDSource, PIDOutpu
         m_pidController.setOutputRange(-1, 1); // Set the output range so that this works with our PercentVbus turning method
         m_pidController.setInputRange(-5 * Math.abs(m_revs), 5 * Math.abs(m_revs)); // We limit our input range to revolutions, either direction
         m_pidController.setAbsoluteTolerance(2*(1 / (3 * (2 * Math.PI)))); // This is the tolerance for error for reaching our target, targeting one inch
-
+        m_pidController.setToleranceBuffer(20); // This is to prevent overshoot
+        
         requires(m_drivetrain);
     }
 

--- a/src/org/usfirst/frc/team4915/steamworks/commands/DriveStraightCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/DriveStraightCommand.java
@@ -17,17 +17,21 @@ public class DriveStraightCommand extends Command implements PIDSource, PIDOutpu
     private double m_inches;
     private double m_revs;
     private double m_heading;
+    private double m_speed;
     
     private static final double IMU_CORRECTION = 0.25;
     private static final double MAX_DEGREES_ERROR = .125;
 
     private static final double k_P = 1.43, k_D = 0, k_I = 0, k_F = 0; // Working P 1.43
 
-    public DriveStraightCommand(Drivetrain drivetrain, double inches)
+    public DriveStraightCommand(Drivetrain drivetrain, double inches, double speed)
     {
         m_drivetrain = drivetrain;
-        // Adjust for negative direction logic of ArcadeDrive
+        
+        // Adjust for negative direction logic of ArcadeDrive (Do this better next year!)
         m_inches = -inches;
+        
+        m_speed = speed;
         m_revs = m_drivetrain.getInchesToRevolutions(m_inches);
         m_pidController = new PIDController(k_P, k_D, k_I, k_F, this, this);
         m_pidController.setOutputRange(-1, 1); // Set the output range so that this works with our PercentVbus turning method
@@ -42,7 +46,7 @@ public class DriveStraightCommand extends Command implements PIDSource, PIDOutpu
     {
         m_drivetrain.m_logger.info("DriveStraightCommand initialize");
         m_drivetrain.setControlMode(TalonControlMode.PercentVbus, 6.0, -6.0, // This was 3 and -3
-                0.0, 0, 0, 0 /* zero PIDF */);
+                0.0, 0, 0, 0 /* zero PIDF */, m_speed /* RobotDrive MaxOutput */);
         m_drivetrain.resetPosition();
         m_pidController.reset(); // Reset all of the things that have been passed to the IMU in any previous usages
         m_pidController.setSetpoint(m_revs); // Set the point we want to turn to

--- a/src/org/usfirst/frc/team4915/steamworks/commands/DriveStraightCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/DriveStraightCommand.java
@@ -37,7 +37,7 @@ public class DriveStraightCommand extends Command implements PIDSource, PIDOutpu
         m_pidController.setOutputRange(-1, 1); // Set the output range so that this works with our PercentVbus turning method
         m_pidController.setInputRange(-5 * Math.abs(m_revs), 5 * Math.abs(m_revs)); // We limit our input range to revolutions, either direction
         m_pidController.setAbsoluteTolerance(2*(1 / (3 * (2 * Math.PI)))); // This is the tolerance for error for reaching our target, targeting one inch
-        
+
         requires(m_drivetrain);
     }
 

--- a/src/org/usfirst/frc/team4915/steamworks/commands/DriveTimedCurveCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/DriveTimedCurveCommand.java
@@ -1,0 +1,37 @@
+package org.usfirst.frc.team4915.steamworks.commands;
+
+import org.usfirst.frc.team4915.steamworks.subsystems.Drivetrain;
+
+import org.usfirst.frc.team4915.steamworks.commands.DriveStraightCommand;
+
+/**
+ * Extends drive straight command and adds a curve after a certain number of inches.
+ */
+public class DriveTimedCurveCommand extends DriveStraightCommand {
+    
+    private Drivetrain m_drivetrain;
+    private double m_straightInches;
+    private double m_straightRevs;
+    private double m_curve;
+
+    public DriveTimedCurveCommand(Drivetrain drivetrain, double totalInches, double curve, double straightInches)
+    {
+        super(drivetrain, totalInches);
+        m_drivetrain = drivetrain;
+        m_straightInches = straightInches;
+        m_curve = curve;
+        m_straightRevs = m_drivetrain.getInchesToRevolutions(m_straightInches);
+    }
+    
+    // PIDOutput -----------------------------------------------------------------------
+    @Override
+    public void pidWrite(double output)
+    {
+        if (m_drivetrain.getOpenLoopValue() >= m_straightRevs) { // If we're over the number of revolutions we want to drive straight with, add the curve
+            m_drivetrain.driveArcadeDirect(output, m_curve);
+        } else {
+            m_drivetrain.driveArcadeDirect(output, super.getIMUCorrection());
+        }
+    }
+    
+}

--- a/src/org/usfirst/frc/team4915/steamworks/commands/DriveTimedCurveCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/DriveTimedCurveCommand.java
@@ -13,14 +13,22 @@ public class DriveTimedCurveCommand extends DriveStraightCommand {
     private double m_straightInches;
     private double m_straightRevs;
     private double m_curve;
+    private double m_speed;
 
-    public DriveTimedCurveCommand(Drivetrain drivetrain, double totalInches, double curve, double straightInches)
+    public DriveTimedCurveCommand(Drivetrain drivetrain, double totalInches, double curve, double straightInches, double speed)
     {
         super(drivetrain, totalInches);
         m_drivetrain = drivetrain;
         m_straightInches = straightInches;
         m_curve = curve;
+        m_speed = speed;
         m_straightRevs = m_drivetrain.getInchesToRevolutions(m_straightInches);
+    }
+    
+    @Override
+    public void initialize() {
+        super.initialize();
+        m_drivetrain.setRobotDriveMaxOutput(m_speed);
     }
     
     // PIDOutput -----------------------------------------------------------------------

--- a/src/org/usfirst/frc/team4915/steamworks/commands/TurnDegreesIMUCommand.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/TurnDegreesIMUCommand.java
@@ -31,7 +31,7 @@ public class TurnDegreesIMUCommand extends Command
         m_drivetrain.endIMUTurn();
         m_drivetrain.setIMUPIDAbsoluteTolerance(3); // We set this to make sure that we don't get the value from FastTurnDegreesIMUCommand
         m_drivetrain.setControlMode(TalonControlMode.PercentVbus, 6.0, -6.0, // This is the same as DriveStraight because it is probably overriden if a command is run before it
-                0, 0, 0, 0 /* zeros since we're not in closed-loop */);
+                0, 0, 0, 0 /* zeros since we're not in closed-loop */, 0.5);
         m_drivetrain.startIMUTurnAbsolute(m_degrees);
         m_drivetrain.m_logger.debug("TurnDegreesIMUCommand I want to turn  "+m_degrees+" degrees.");
         m_drivetrain.m_logger.info("TurnDegreesIMUCommand initalized");

--- a/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
@@ -47,12 +47,17 @@ public class ParameterizedCommandGroup extends CommandGroup
             {
                 case "Drive":
                 	double distance = safeParseDouble(params[i++]);
-                    addSequential(new DriveStraightCommand(drivetrain, distance));
+                    addSequential(new DriveStraightCommand(drivetrain, distance, Drivetrain.MAX_OUTPUT_ROBOT_DRIVE));
+                    break;
+                case "Drive Speed":
+                    distance = safeParseDouble(params[i++]);
+                    double speed = safeParseDouble(params[i++]);
+                    addSequential(new DriveStraightCommand(drivetrain, distance, speed));
                     break;
                 case "Drive Timeout":
                     distance = safeParseDouble(params[i++]);
                     double timeout = safeParseDouble(params[i++]);
-                    addSequential(new DriveStraightCommand(drivetrain, distance), timeout);
+                    addSequential(new DriveStraightCommand(drivetrain, distance, Drivetrain.MAX_OUTPUT_ROBOT_DRIVE), timeout);
                     break;
                 case "Curve":
                 	distance = safeParseDouble(params[i++]);
@@ -77,8 +82,10 @@ public class ParameterizedCommandGroup extends CommandGroup
                     double totalDistance = safeParseDouble(params[i++]);
                     curve = safeParseDouble(params[i++]);
                     double straightDistance = safeParseDouble(params[i++]);
-                    double speed = safeParseDouble(params[i++]);
-                    addSequential(new DriveTimedCurveCommand(drivetrain, totalDistance, curve, straightDistance, speed));
+                    speed = safeParseDouble(params[i++]);
+                    boolean reverse = Boolean.parseBoolean(params[i++]);
+                    addSequential(new DriveTimedCurveCommand(drivetrain, totalDistance, curve * oi.getAllianceScale(), straightDistance, speed, reverse));
+                    break;
                 case "Intake": // This command runs in parallel
                     Intake.State intakeState;
                     String currentParam = params[i++];
@@ -90,6 +97,7 @@ public class ParameterizedCommandGroup extends CommandGroup
                         intakeState = Intake.State.OFF;
                     }
                     addParallel(new IntakeSetCommand(intake, intakeState));
+                    break;
                 case "Delay":
                     double delay = safeParseDouble(params[i++]);
                     addSequential(new DelayCommand(delay));

--- a/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
@@ -5,11 +5,14 @@ import org.usfirst.frc.team4915.steamworks.OI;
 import org.usfirst.frc.team4915.steamworks.commands.DriveCurveCommand;
 import org.usfirst.frc.team4915.steamworks.commands.DelayCommand;
 import org.usfirst.frc.team4915.steamworks.commands.DriveStraightCommand;
+import org.usfirst.frc.team4915.steamworks.commands.DriveTimedCurveCommand;
 import org.usfirst.frc.team4915.steamworks.commands.FastTurnDegreesIMUCommand;
+import org.usfirst.frc.team4915.steamworks.commands.IntakeSetCommand;
 import org.usfirst.frc.team4915.steamworks.commands.LauncherCommand;
 import org.usfirst.frc.team4915.steamworks.commands.StopCommand;
 import org.usfirst.frc.team4915.steamworks.commands.TurnDegreesIMUCommand;
 import org.usfirst.frc.team4915.steamworks.subsystems.Drivetrain;
+import org.usfirst.frc.team4915.steamworks.subsystems.Intake;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher;
 import org.usfirst.frc.team4915.steamworks.subsystems.Launcher.LauncherState;
 
@@ -30,7 +33,7 @@ public class ParameterizedCommandGroup extends CommandGroup
      * Please don't do it this way next year. 
      * See Jack's suggestion: https://github.com/Spartronics4915/2017-STEAMworks/pull/59#pullrequestreview-22671451
      */
-    public ParameterizedCommandGroup(Drivetrain drivetrain, Launcher launcher, OI oi, String... params)
+    public ParameterizedCommandGroup(Drivetrain drivetrain, Launcher launcher, Intake intake, OI oi, String... params)
     {
         m_logger = new Logger("ParameterizedCommandGroup", Logger.Level.DEBUG);
         
@@ -70,6 +73,22 @@ public class ParameterizedCommandGroup extends CommandGroup
                 case "Stop":
                     addSequential(new StopCommand(drivetrain)); // Takes no parameters
                     break;
+                case "Straight and Curve":
+                    double totalDistance = safeParseDouble(params[i++]);
+                    curve = safeParseDouble(params[i++]);
+                    double straightDistance = safeParseDouble(params[i++]);
+                    addSequential(new DriveTimedCurveCommand(drivetrain, totalDistance, curve, straightDistance));
+                case "Intake": // This command runs in parallel
+                    Intake.State intakeState;
+                    String currentParam = params[i++];
+                    if (currentParam == "ON") {
+                        intakeState = Intake.State.ON;
+                    } else if (currentParam == "REVERSE") {
+                        intakeState = Intake.State.REVERSE;
+                    } else {
+                        intakeState = Intake.State.OFF;
+                    }
+                    addParallel(new IntakeSetCommand(intake, intakeState));
                 case "Delay":
                     double delay = safeParseDouble(params[i++]);
                     addSequential(new DelayCommand(delay));

--- a/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
@@ -77,7 +77,8 @@ public class ParameterizedCommandGroup extends CommandGroup
                     double totalDistance = safeParseDouble(params[i++]);
                     curve = safeParseDouble(params[i++]);
                     double straightDistance = safeParseDouble(params[i++]);
-                    addSequential(new DriveTimedCurveCommand(drivetrain, totalDistance, curve, straightDistance));
+                    double speed = safeParseDouble(params[i++]);
+                    addSequential(new DriveTimedCurveCommand(drivetrain, totalDistance, curve, straightDistance, speed));
                 case "Intake": // This command runs in parallel
                     Intake.State intakeState;
                     String currentParam = params[i++];

--- a/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
+++ b/src/org/usfirst/frc/team4915/steamworks/commands/groups/ParameterizedCommandGroup.java
@@ -72,6 +72,11 @@ public class ParameterizedCommandGroup extends CommandGroup
                     angle = safeParseDouble(params[i++]);
                     timeout = safeParseDouble(params[i++]);
                     addSequential(new TurnDegreesIMUCommand(drivetrain, angle * oi.getAllianceScale()), timeout);
+		    break;
+		case "Turn Alliance Independent Timeout":
+		    angle = safeParseDouble(params[i++]);
+		    timeout = safeParseDouble(params[i++]);
+		    addSequential(new TurnDegreesIMUCommand(drivetrain, angle), timeout);
                     break;
                 case "Turn Fast":
                     double value = safeParseDouble(params[i++]);

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -85,9 +85,9 @@ public class Drivetrain extends SpartronicsSubsystem
     private IMUPIDSource m_imuPIDSource;
 
     // PID Values for IMU turning
-    private static final double turnKp = 0.11;
+    private static final double turnKp = 0.09;
     private static final double turnKi = 0.01;
-    private static final double turnKd = 0.3;
+    private static final double turnKd = 0.4;
     private static final double turnKf = 0.001;
 
     // Replay

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -46,11 +46,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class Drivetrain extends SpartronicsSubsystem
 {
+    
+    public static final double MAX_OUTPUT_ROBOT_DRIVE = 0.3; //was .3, changing the scaling factor
+    
     private static final double TURN_MULTIPLIER = .4;
 
     private static final int QUAD_ENCODER_CODES_PER_REVOLUTION = 250; // Encoder-specific value, for E4P-250-250-N-S-D-D
     private static final int QUAD_ENCODER_TICKS_PER_REVOLUTION = QUAD_ENCODER_CODES_PER_REVOLUTION * 4; // This should be one full rotation
-    private static final double MAX_OUTPUT_ROBOT_DRIVE = 0.3; //was .3, changing the scaling factor
 //    private static final double WHEEL_DIAMETER = 6; // Not needed right now
     private static final double WHEEL_CIRCUMFERENCE = 20.06; // This is to account for drift
 

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -332,6 +332,11 @@ public class Drivetrain extends SpartronicsSubsystem
         return ticks / (double)QUAD_ENCODER_TICKS_PER_REVOLUTION;
     }
     
+    // A lower-overhead way then setControlMode to set the max output (this shouldn't mess anyone else up if they set control mode)
+    public void setRobotDriveMaxOutput(double maxOutput) {
+        m_robotDrive.setMaxOutput(maxOutput);
+    }
+    
     // Not to be confused with CANTalon's setControlMode... The idea here is to
     // make sure that we keep all the control-mode-specific settings under close
     // management.

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Drivetrain.java
@@ -85,9 +85,9 @@ public class Drivetrain extends SpartronicsSubsystem
     private IMUPIDSource m_imuPIDSource;
 
     // PID Values for IMU turning
-    private static final double turnKp = 0.09;
+    private static final double turnKp = 0.11;
     private static final double turnKi = 0.01;
-    private static final double turnKd = 0.4;
+    private static final double turnKd = 0.3;
     private static final double turnKf = 0.001;
 
     // Replay

--- a/src/org/usfirst/frc/team4915/steamworks/subsystems/Intake.java
+++ b/src/org/usfirst/frc/team4915/steamworks/subsystems/Intake.java
@@ -18,7 +18,7 @@ public class Intake extends SpartronicsSubsystem
         REVERSE
     }
 
-    private static final double INTAKE_SPEED = 0.90;
+    private static final double INTAKE_SPEED = 0.95; // Changed at Cheney (was 0.90)
 
     private CANTalon m_intakeMotor;
 


### PR DESCRIPTION
### _Please review this pull request, and don't merge it until we test at Cheney._
* Added a tolerance buffer in DriveStraightCommand command to make it roll back to the target when it overshoots on speeds it isn't tuned for.
* Added an autonomous option for placing a gear on the boiler side spring.
* Added a command that drive straight and curves (or the other way around if you want), it extends DriveStraightCommand. This was not the best design decision.
* Added parameters to ParameterizedCommandGroup
  * Added a drive with speed parameter
  * Added a drive with timeout parameter
  * Added a turn with timeout parameter
* Re tuned turning PID
* Added an autonomous option for side gear placement
* Increased intake speed by 5%
